### PR TITLE
Make public resources of extensions accessible to web container

### DIFF
--- a/.docker/env.dev.volumes.yml
+++ b/.docker/env.dev.volumes.yml
@@ -9,6 +9,12 @@ services:
       volume:
         nocopy: true
     - type: volume
+      source: typo3confext
+      target: /app/public/typo3conf/ext
+      read_only: true
+      volume:
+        nocopy: true
+    - type: volume
       source: typo3temp
       target: /app/private/typo3temp
       read_only: true
@@ -19,6 +25,7 @@ services:
     volumes:
     - fileadmin:/app/private/fileadmin
     - ./private/fileadmin/form_definitions:/app/private/fileadmin/form_definitions
+    - typo3confext:/app/private/typo3conf/ext
     - typo3temp:/app/private/typo3temp
     - var:/app/var
     - ./var/labels:/app/var/labels
@@ -31,5 +38,6 @@ services:
 volumes:
   db:
   fileadmin:
+  typo3confext:
   typo3temp:
   var:

--- a/.docker/env.prod.yml
+++ b/.docker/env.prod.yml
@@ -9,6 +9,12 @@ services:
       volume:
         nocopy: true
     - type: volume
+      source: typo3confext
+      target: /app/public/typo3conf/ext
+      read_only: true
+      volume:
+        nocopy: true
+    - type: volume
       source: typo3temp
       target: /app/private/typo3temp
       read_only: true
@@ -18,10 +24,12 @@ services:
   typo3:
     volumes:
     - fileadmin:/app/private/fileadmin
+    - typo3confext:/app/private/typo3conf/ext
     - typo3temp:/app/private/typo3temp
     - var:/app/var
 
 volumes:
   fileadmin:
+  typo3confext:
   typo3temp:
   var:


### PR DESCRIPTION
Hi,
thank you very much for this docker and composer based TYPO3 setup. I have used it for testing purposes when doing extension development.
I had to add another volume to make the resources of the extension available to the web container, which means to the web client / browser.
I hope this pull request reflects this change in a correct manner and it is helpful for other working with this setup. 